### PR TITLE
preserve msg information in RedisCmd node

### DIFF
--- a/redis.js
+++ b/redis.js
@@ -46,10 +46,10 @@ module.exports = function (RED) {
             node.topics = [];
             done();
         });
-        
+
         node.client.select(node.server.dbase, function () {
             node.topics = node.topic.split(' ');
-            if (node.command === "psubscribe" || node.command === "subscribe") {   
+            if (node.command === "psubscribe" || node.command === "subscribe") {
                 node.client.on('subscribe', function (channel, count) {
                     node.status({fill: "green", shape: "dot", text: "connected"});
                 });
@@ -149,7 +149,8 @@ module.exports = function (RED) {
                     if (err) {
                         node.error(err);
                     }
-                    node.send({payload: res});
+                    msg.payload = res;
+                    node.send(msg);
                 });
             });
         });

--- a/redis.js
+++ b/redis.js
@@ -22,7 +22,7 @@ module.exports = function (RED) {
         this.timeout = n.timeout;
         this.sto = null;
         this.topics = [];
-        this.client = connect(n.server, true);
+        this.client = connect(this.server, true);
         var node = this;
 
         node.client.on('error', function (err) {

--- a/redis.js
+++ b/redis.js
@@ -89,12 +89,6 @@ module.exports = function (RED) {
 
         var client = connect(node.server);
 
-        client.on('error', function (err) {
-            if (err) {
-                node.error(err);
-            }
-        });
-
         node.on('close', function (done) {
             node.status({});
             disconnect(node.server);
@@ -126,12 +120,6 @@ module.exports = function (RED) {
         var node = this;
 
         var client = connect(node.server);
-
-        client.on('error', function (err) {
-            if (err) {
-                node.error(err);
-            }
-        });
 
         node.on('close', function (done) {
             node.status({});
@@ -169,6 +157,9 @@ module.exports = function (RED) {
                 options['auth_pass'] = config.pass;
             }
             var conn = redis.createClient(config.port, config.host, options);
+            conn.on('error', function (err) {
+                console.log('[redis]', err);
+            })
             if (force !== undefined && force === true) {
                 return conn;
             } else {


### PR DESCRIPTION
There might be extra information in the input `msg` object. Changing `msg.payload` then send `msg` is better than just sending `{payload: res}`