### PR TITLE
Fix wild topic variable in RedisOut

### DIFF
--- a/redis.js
+++ b/redis.js
@@ -96,7 +96,7 @@ module.exports = function (RED) {
         });
 
         node.on('input', function (msg) {
-
+            var topic;
             if (msg.topic !== undefined && msg.topic !== "") {
                 topic = msg.topic;
             } else {


### PR DESCRIPTION
Using an undefined variable as topic makes it global. When multiple messages with different
topics arrive simultaneously, they would end up using the same topic. Declaring it as a local variable fix the problem.