### PR TITLE
fix: command node always using msg topic and ignoring node topic

### DIFF
--- a/redis.js
+++ b/redis.js
@@ -206,7 +206,7 @@ module.exports = function (RED) {
       send = send || function() { node.send.apply(node,arguments) }
       done = done || function(err) { if(err)node.error(err, msg); }
 
-      if (msg.topic) {
+      if (msg.topic !== undefined && msg.topic !== "") {
         topic = msg.topic;
       } else if (node.topic && node.topic !== "") {
         try {


### PR DESCRIPTION
When trying to setup a topic on a command node the topic was always with value "".

At the code the criteria was just checking just if the msg.topic was true, since it comes as a empty string was always true.

One question. Shouldn't the node.topic overrides the msg one?