### PR TITLE
Update redis.js to support non-local servers

### DIFF
--- a/redis.js
+++ b/redis.js
@@ -23,7 +23,7 @@ module.exports = function (RED) {
 
   function RedisIn(n) {
     RED.nodes.createNode(this, n);
-    this.server = RED.nodes.getNode(n.server);
+    this.server = n.server; // Shoudln't this be the server and port? I'm not able to get this to connect to non-local redis. Was RED.nodes.getNode(n.server);
     this.command = n.command;
     this.name = n.name;
     this.topic = n.topic;


### PR DESCRIPTION
I'm unable to get this to connect to non-local Redis. I'm no NodeJS coder, but it seems from the IoRedis that the server options should be the ip and port and it looks like the get.node function would return NULL (as the n.server is not a valid node id) causing the Redis function to connect to local host always.