### PR TITLE
Update redis.js

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,8 @@
-# node-red-contrib-redis
+# node-red-v4-contrib-redis
 Node Red client for Redis with pub/sub, list, lua scripting, ssl, cluster, custom commands, instance injection and other commands support.
+
+This is a fork from the excellent node-red-contrib-redis with a small patch to make it compliant with the upcoming (Feb.24) Node Red v4. 
+The proposed patch to the main branch was not considered. The repo seems abandoned.
 
 Connection Options parameter receives IORedis object or string (https://github.com/luin/ioredis#connect-to-redis).
 

--- a/redis.js
+++ b/redis.js
@@ -5,18 +5,18 @@ module.exports = function (RED) {
   let connections = {};
   let usedConn = {};
 
-  function RedisConfig(n) {
+function RedisConfig(n) {
     RED.nodes.createNode(this, n);
     this.name = n.name;
     this.cluster = n.cluster;
     if (this.optionsType === "") {
       this.options = n.options;
     } else {
-      this.options = RED.util.evaluateNodeProperty(
-        n.options,
-        n.optionsType,
-        this
-      );
+      RED.util.evaluateNodeProperty(n.options, n.optionsType,this,undefined,(err,value) => {
+           if(!err) {
+            this.options = value
+          }
+      });
     }
   }
   RED.nodes.registerType("redis-config", RedisConfig);


### PR DESCRIPTION
In NodeRed 4.0 the callback function in evaluateNodeProperty is mandatory. The proposed change is coming from https://discourse.nodered.org/t/understanding-and-fixing-warning-message/83398