### PR TITLE
Enhance Redis Config Node to Handle JSON Strings from Environment Variables

### DIFF
--- a/redis.js
+++ b/redis.js
@@ -13,8 +13,18 @@ function RedisConfig(n) {
       this.options = n.options;
     } else {
       RED.util.evaluateNodeProperty(n.options, n.optionsType,this,undefined,(err,value) => {
-           if(!err) {
-            this.options = value
+          if(!err) {
+            // Check if value is a string and optionsType is "env"
+            if (typeof value === 'string' && n.optionsType === "env") {
+                try {
+                    this.options = JSON.parse(value); // Attempt to parse JSON
+                } catch (e) {
+                    console.warn("Failed to parse env as JSON string in redis-config node, use plain value:", e);
+                    this.options = value;  // Keep the value as is if it's not valid JSON
+                }
+            } else {
+                this.options = value;
+            }
           }
       });
     }


### PR DESCRIPTION
This PR addresses an issue where selecting `env` as the configuration source and providing a string value would incorrectly treat the string as a hostname. If the string is actually a JSON configuration, this results in an error as the JSON string is incorrectly used as a hostname.

#### Changes:

* Added a check to determine if the value is a string and if the configuration type is env.
* Attempt to parse the string as JSON if both conditions are met.
    * If JSON parsing is successful, use the resulting object for the configuration.
    * If JSON parsing fails, keep the string value as is, ensuring the previous behavior remains unchanged.


When env is selected as the configuration source and the value is a string, it can either be a simple hostname or a JSON configuration. Without this change, JSON strings cause errors since they are misinterpreted as hostnames. This enhancement ensures that environment variable configurations are more flexible. This improves the usability of the Redis Config Node in environments where configuration is provided via environment variables like in Docker or Kubernetes.

#### Example 1:
```
REDIS_CONFIG = '{"host":"localhost","port":6379}'
```
is parsed and used as a object.
```
REDIS_CONFIG = 'localhost'
```
continues to be used as a hostname.


#### Example 2:
in my use-case i execute NodeRED in Kubernetes and pass configurations via environment variables to it. For anyone how is interested, here is a snipped of my manifest and how I use it in NodeRed:

```yaml
    spec:
      containers:
        - name: nodered
          image: nodered/node-red:4.0.2
          env:
            - name: REDIS_CONFIG
              value: |
                {
                  "host": "redis-server",
                  "port": 6379,
                  "db": 0,
                  "username": "$(redis_username)",
                  "password": "$(redis_password)"
                }
          envFrom:
            - secretRef:
                name: redis-user-nodered  # containes redis_username redis_password
```

![grafik](https://github.com/user-attachments/assets/eeb93243-d94a-4eea-8a46-54bbe7d1280e)

```
[{"id":"e3b3d83b76ec9607","type":"redis-instance","z":"ec1fd2a9a2f3cff8","server":"73589485eb3882eb","name":"","topic":"Redis","location":"global","x":190,"y":180,"wires":[]},{"id":"73589485eb3882eb","type":"redis-config","name":"Redis","options":"REDIS_CONFIG","cluster":false,"optionsType":"env"}]
```




